### PR TITLE
Disable serde-arbitrary-precision feature of rust-decimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,7 @@ members = [
     "crates/erc20_payment_lib_test",
     "crates/web3_test_proxy_client",
 ]
-exclude = [
-    "crates/web3_test_proxy",
-]
+exclude = ["crates/web3_test_proxy"]
 
 [[bin]]
 name = "erc20_processor"
@@ -24,7 +22,9 @@ license = "MIT"
 [workspace.dependencies]
 actix-cors = "0.6.4"
 actix-files = "0.6.2"
-actix-web = { version = "^4.2.1", default-features = false, features = ["macros"] }
+actix-web = { version = "^4.2.1", default-features = false, features = [
+    "macros",
+] }
 anyhow = "1.0.71"
 async-trait = "0.1.68"
 awc = "3.1.1"
@@ -46,7 +46,7 @@ log = "0.4.17"
 mime_guess = "2.0.3"
 rand = "0.8.5"
 rust-embed = "6.8.1"
-rust_decimal = { version = "1.26.1", features = ["serde-arbitrary-precision"] }
+rust_decimal = "1.26.1"
 rustc-hex = "2.1.0"
 secp256k1 = "0.27.0" # version has to match web3
 serde = "^1.0.147"
@@ -59,8 +59,10 @@ thiserror = "1.0.37"
 tokio = { version = "^1.21", features = ["macros", "rt-multi-thread"] }
 toml = "0.5.9" # need some refactor to update
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
-web3 = { version = "0.19.0", default-features = false, features = ["signing", "http-rustls-tls"] }
-
+web3 = { version = "0.19.0", default-features = false, features = [
+    "signing",
+    "http-rustls-tls",
+] }
 
 
 [dependencies]
@@ -101,7 +103,7 @@ erc20_payment_lib = { path = "crates/erc20_payment_lib" }
 erc20_payment_lib_extra = { path = "crates/erc20_payment_lib_extra" }
 
 [dev-dependencies]
-bollard = { workspace = true}
+bollard = { workspace = true }
 erc20_payment_lib_test = { path = "crates/erc20_payment_lib_test" }
 web3_test_proxy_client = { path = "crates/web3_test_proxy_client" }
 awc = { workspace = true }

--- a/crates/web3_test_proxy/Cargo.toml
+++ b/crates/web3_test_proxy/Cargo.toml
@@ -14,10 +14,12 @@ name = "web3_test_proxy"
 [dependencies]
 actix-cors = { version = "0.6.4" }
 actix-files = { version = "0.6.2" }
-actix-web = { version = "^4.2.1", default-features = false, features = ["macros"] }
-awc =  "3.1.1"
+actix-web = { version = "^4.2.1", default-features = false, features = [
+    "macros",
+] }
+awc = "3.1.1"
 base64 = "0.21.2"
-chrono = { version="0.4.22", features = ["serde"] }
+chrono = { version = "0.4.22", features = ["serde"] }
 dotenv = "0.15.0"
 env_logger = "0.10.0"
 hex = "0.4.3"
@@ -26,7 +28,7 @@ log = "0.4.17"
 mime_guess = "2.0.3"
 rand = "0.8.5"
 rust-embed = "6.8.1"
-rust_decimal = { version = "1.26.1", features = ["serde-arbitrary-precision"] }
+rust_decimal = "1.26.1"
 rustc-hex = "2.1.0"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = { version = "^1.0.85" }


### PR DESCRIPTION
...which enabled the arbitrary-precision feature of serde-json, which broke yagna. This is because gsb-api relies on json integers being serialized as flexbuffer numbers, while arbitrary-precision makes them serialize as serde-json-specific structures. Besides that if we ever use numbers in the REST API we would obviously serialize them in a way unusable from JS/Python.

This cannot be sensibly worked around, because cargo assumes crate features are strictly additive and one cannot depend on the same library twice with the only difference being the set of enabled features.

rust-decimal Decimals were only serialized in informational messages which do not affect the correctness of the driver, so this change does not affect any financial computations.